### PR TITLE
Chore/issue 71 add requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+django >= 4.0.4
+django-crispy-forms == 1.14
+django-tinymce >= 3.4.0
+django-allauth >= 0.50.0
+django-mptt >= 0.13.4
+psycopg2 >= 2.9.9

--- a/vol/admin.py
+++ b/vol/admin.py
@@ -1,7 +1,7 @@
 # coding=UTF-8
 
 from django.contrib import admin, messages
-from django.contrib.gis.admin import GeoModelAdmin
+from django.contrib.gis.admin import GISModelAdmin
 from django.templatetags.static import static
 from django.db import transaction, DatabaseError
 from django.utils.translation import gettext, gettext_lazy as _
@@ -463,7 +463,7 @@ class BaseEntidadeAdmin(admin.ModelAdmin):
     email_confirmado.short_description = u'E-mail confirmado'
 
 @admin.register(Entidade)
-class EntidadeAdmin(GeoModelAdmin, BaseEntidadeAdmin):
+class EntidadeAdmin(GISModelAdmin, BaseEntidadeAdmin):
     list_display = ('razao_social', 'cnpj', 'email_principal', 'data_cadastro', 'email_confirmado', 'aprovado',)
     ordering = ('-aprovado', '-data_cadastro',)
     search_fields = ('nome_fantasia', 'razao_social', 'cnpj', 'email_set__endereco',)

--- a/vol/auth.py
+++ b/vol/auth.py
@@ -3,7 +3,6 @@
 from django import forms
 
 from allauth.account.adapter import DefaultAccountAdapter, get_adapter
-from allauth.utils import email_address_exists
 from allauth.account.forms import SignupForm
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.account.models import EmailAddress


### PR DESCRIPTION
Essas modificações fecham a [issue 71](https://github.com/regiov/voluntarios/issues/71), adicionando um arquivo requirements.txt, que possui as dependências necessárias ao projeto e suas respectivas versões. Dessa forma, para instalar as dependências, basta rodar `pip install -r requirements.txt`.